### PR TITLE
Fixed download shortcut (CTRL+s)

### DIFF
--- a/server/nashi/static/editor.js
+++ b/server/nashi/static/editor.js
@@ -140,7 +140,7 @@ Nashi.prototype.shortcuts = {
 					case "KeyS":
 						if (evt.ctrlKey){
 							e.preventDefault();
-		        	downloadxml();
+							nsh.downloadXML();
 						}
 					break;
 


### PR DESCRIPTION
Fixed function call for the download XML shortcut (CTRL+s)

![download_shortcut](https://user-images.githubusercontent.com/23743591/56344903-cf3be400-61be-11e9-9bc5-9d30d6e01ff1.png)

Issue:
- nashi will not download the PAGE XML with the CTRL+s shortcut described in the nashi [README](https://github.com/andbue/nashi/blob/master/README.md)

How to reproduce:
- Open nashi and hit CTRL+s 
